### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,5 @@ command from within each of client subdirectories:
 
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
-[Spring Web Services]: http://projects.spring.io/spring-ws
+[Spring Web Services]: https://projects.spring.io/spring-ws
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/airline/README.md
+++ b/airline/README.md
@@ -14,5 +14,5 @@ See the main [README](../README.md) for build instructions.
 
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
-[Spring Web Services]: http://projects.spring.io/spring-ws
+[Spring Web Services]: https://projects.spring.io/spring-ws
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/airline/client/airline.wsdl
+++ b/airline/client/airline.wsdl
@@ -48,7 +48,7 @@
     </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="AirlineSoap11" type="tns:Airline">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
     <wsdl:operation name="BookFlight">
       <soap:operation soapAction=""/>
       <wsdl:input name="BookFlightRequest">

--- a/echo/README.md
+++ b/echo/README.md
@@ -11,5 +11,5 @@ See the main [README](../README.md) for build instructions.
 
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
-[Spring Web Services]: http://projects.spring.io/spring-ws
+[Spring Web Services]: https://projects.spring.io/spring-ws
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/mtom/README.md
+++ b/mtom/README.md
@@ -10,5 +10,5 @@ See the main [README](../README.md) for build instructions.
 
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
-[Spring Web Services]: http://projects.spring.io/spring-ws
+[Spring Web Services]: https://projects.spring.io/spring-ws
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/mtom/client/jax-ws/mtom.wsdl
+++ b/mtom/client/jax-ws/mtom.wsdl
@@ -4,7 +4,7 @@
                                                                         xmlns:tns="http://www.springframework.org/spring-ws/samples/mtom"
                                                                         targetNamespace="http://www.springframework.org/spring-ws/samples/mtom">
   <wsdl:types>
-    <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xmime="http://www.w3.org/2005/05/xmlmime"
+    <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xmime="https://www.w3.org/2005/05/xmlmime"
             elementFormDefault="qualified" targetNamespace="http://www.springframework.org/spring-ws/samples/mtom"
             xmlns:tns="http://www.springframework.org/spring-ws/samples/mtom">
 
@@ -48,7 +48,7 @@
     </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="ImageRepositorySoap11" type="tns:ImageRepository">
-    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
     <wsdl:operation name="StoreImage">
       <soap:operation soapAction=""/>
       <wsdl:input name="StoreImageRequest">

--- a/mtom/server/src/main/resources/schema.xsd
+++ b/mtom/server/src/main/resources/schema.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.springframework.org/spring-ws/samples/mtom"
         xmlns:tns="http://www.springframework.org/spring-ws/samples/mtom"
-        xmlns:xmime="http://www.w3.org/2005/05/xmlmime" elementFormDefault="qualified">
+        xmlns:xmime="https://www.w3.org/2005/05/xmlmime" elementFormDefault="qualified">
 
     <element name="StoreImageRequest" type="tns:Image"/>
 

--- a/stockquote/README.md
+++ b/stockquote/README.md
@@ -27,5 +27,5 @@ each of client subdirectories:
 
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
-[Spring Web Services]: http://projects.spring.io/spring-ws
+[Spring Web Services]: https://projects.spring.io/spring-ws
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/stockquote/server/src/main/resources/org/springframework/ws/samples/stockquote/ws/stockquote.wsdl
+++ b/stockquote/server/src/main/resources/org/springframework/ws/samples/stockquote/ws/stockquote.wsdl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
-                  xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl"
+                  xmlns:wsaw="https://www.w3.org/2006/05/addressing/wsdl"
                   xmlns:tns="http://www.springframework.org/spring-ws/samples/stockquote"
                   targetNamespace="http://www.springframework.org/spring-ws/samples/stockquote">
     <wsdl:types>
@@ -53,7 +53,7 @@
         </wsdl:operation>
     </wsdl:portType>
     <wsdl:binding name="StockSoap11" type="tns:Stock">
-        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http/"/>
         <wsaw:UsingAddressing wsdl:required="true"/>
         <wsdl:operation name="StockQuote">
             <soap:operation soapAction=""/>

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -16,5 +16,5 @@ This sample contains the code for the tutorial, which can be found in the
 
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
-[Spring Web Services]: http://projects.spring.io/spring-ws
+[Spring Web Services]: https://projects.spring.io/spring-ws
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0

--- a/weather/README.md
+++ b/weather/README.md
@@ -14,6 +14,6 @@ You can run the client by using the following command from within this directory
 
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
-[Spring Web Services]: http://projects.spring.io/spring-ws
+[Spring Web Services]: https://projects.spring.io/spring-ws
 [Apache License]: http://www.apache.org/licenses/LICENSE-2.0
-[CDYNE Weather Service]: http://wiki.cdyne.com/index.php/CDYNE_Weather
+[CDYNE Weather Service]: https://wiki.cdyne.com/index.php/CDYNE_Weather

--- a/weather/src/main/java/org/springframework/ws/samples/weather/WeatherClient.java
+++ b/weather/src/main/java/org/springframework/ws/samples/weather/WeatherClient.java
@@ -35,7 +35,7 @@ public class WeatherClient extends WebServiceGatewaySupport {
 		GetCityForecastByZIPResponse response =
 				(GetCityForecastByZIPResponse) getWebServiceTemplate()
 						.marshalSendAndReceive(request, new SoapActionCallback(
-								"http://ws.cdyne.com/WeatherWS/GetCityForecastByZIP"));
+								"https://ws.cdyne.com/WeatherWS/GetCityForecastByZIP"));
 
 		return response;
 	}


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://schemas.xmlsoap.org/wsdl/ (200) with 3 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/wsdl/) result AnnotatedConnectException).
* [ ] http://schemas.xmlsoap.org/wsdl/soap/ (200) with 3 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/wsdl/soap/) result AnnotatedConnectException).
* [ ] http://wsf.cdyne.com/WeatherWS/Weather.asmx (200) with 1 occurrences could not be migrated:  
   ([https](https://wsf.cdyne.com/WeatherWS/Weather.asmx) result ConnectTimeoutException).
* [ ] http://schemas.xmlsoap.org/soap/http (301) with 3 occurrences could not be migrated:  
   ([https](https://schemas.xmlsoap.org/soap/http) result AnnotatedConnectException).
* [ ] http://mycompany.com/hr/definitions (404) with 1 occurrences could not be migrated:  
   ([https](https://mycompany.com/hr/definitions) result ConnectTimeoutException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://wiki.cdyne.com/index.php/CDYNE_Weather (301) with 1 occurrences migrated to:  
  https://wiki.cdyne.com/index.php/CDYNE_Weather ([https](https://wiki.cdyne.com/index.php/CDYNE_Weather) result SSLHandshakeException).
* [ ] http://ws.cdyne.com/WeatherWS/GetCityForecastByZIP (404) with 1 occurrences migrated to:  
  https://ws.cdyne.com/WeatherWS/GetCityForecastByZIP ([https](https://ws.cdyne.com/WeatherWS/GetCityForecastByZIP) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.w3.org/2005/05/xmlmime with 2 occurrences migrated to:  
  https://www.w3.org/2005/05/xmlmime ([https](https://www.w3.org/2005/05/xmlmime) result 200).
* [ ] http://projects.spring.io/spring-ws with 7 occurrences migrated to:  
  https://projects.spring.io/spring-ws ([https](https://projects.spring.io/spring-ws) result 301).
* [ ] http://www.w3.org/2006/05/addressing/wsdl with 1 occurrences migrated to:  
  https://www.w3.org/2006/05/addressing/wsdl ([https](https://www.w3.org/2006/05/addressing/wsdl) result 301).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 5 occurrences
* http://localhost:8080/StockService with 3 occurrences
* http://localhost:8080/airline-server/services with 2 occurrences
* http://localhost:8080/echo-server/services with 2 occurrences
* http://localhost:8080/echo/services with 1 occurrences
* http://localhost:8080/mtom-server/ with 2 occurrences
* http://localhost:8080/mtom-server/services with 2 occurrences
* http://localhost:8080/tutorial/holiday.wsdl with 2 occurrences
* http://mycompany.com/hr/schemas with 3 occurrences
* http://www.joda.org/joda/time/tags with 2 occurrences
* http://www.springframework.org/spring-ws/samples/airline/definitions with 3 occurrences
* http://www.springframework.org/spring-ws/samples/airline/schemas/messages with 11 occurrences
* http://www.springframework.org/spring-ws/samples/airline/schemas/types with 10 occurrences
* http://www.springframework.org/spring-ws/samples/echo with 3 occurrences
* http://www.springframework.org/spring-ws/samples/mtom with 11 occurrences
* http://www.springframework.org/spring-ws/samples/stockquote with 5 occurrences
* http://www.springframework.org/spring-ws/samples/stockquote/StockService/GetQuote with 3 occurrences
* http://www.springframework.org/spring-ws/samples/stockquote/StockService/Quotes with 2 occurrences
* http://www.springframework.org/tags with 1 occurrences
* http://www.w3.org/2001/XMLSchema with 9 occurrences