### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,4 @@ command from within each of client subdirectories:
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
 [Spring Web Services]: https://projects.spring.io/spring-ws
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/airline/README.md
+++ b/airline/README.md
@@ -15,4 +15,4 @@ See the main [README](../README.md) for build instructions.
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
 [Spring Web Services]: https://projects.spring.io/spring-ws
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/airline/client/axis1/src/main/java/org/springframework/ws/samples/airline/client/axis1/Main.java
+++ b/airline/client/axis1/src/main/java/org/springframework/ws/samples/airline/client/axis1/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/jax-ws/src/main/java/org/springframework/ws/samples/airline/client/jaxws/Main.java
+++ b/airline/client/jax-ws/src/main/java/org/springframework/ws/samples/airline/client/jaxws/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/jms/src/main/java/org/springframework/ws/samples/airline/client/jms/JmsClient.java
+++ b/airline/client/jms/src/main/java/org/springframework/ws/samples/airline/client/jms/JmsClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/saaj/src/main/java/org/springframework/ws/samples/airline/client/saaj/Driver.java
+++ b/airline/client/saaj/src/main/java/org/springframework/ws/samples/airline/client/saaj/Driver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/saaj/src/main/java/org/springframework/ws/samples/airline/client/saaj/GetFlights.java
+++ b/airline/client/saaj/src/main/java/org/springframework/ws/samples/airline/client/saaj/GetFlights.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/saaj/src/main/java/org/springframework/ws/samples/airline/client/saaj/GetFrequentFlyerMileage.java
+++ b/airline/client/saaj/src/main/java/org/springframework/ws/samples/airline/client/saaj/GetFrequentFlyerMileage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/spring-ws/src/main/java/org/springframework/ws/samples/airline/client/sws/Driver.java
+++ b/airline/client/spring-ws/src/main/java/org/springframework/ws/samples/airline/client/sws/Driver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/spring-ws/src/main/java/org/springframework/ws/samples/airline/client/sws/GetFlights.java
+++ b/airline/client/spring-ws/src/main/java/org/springframework/ws/samples/airline/client/sws/GetFlights.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/spring-ws/src/main/java/org/springframework/ws/samples/airline/client/sws/GetFrequentFlyerMileage.java
+++ b/airline/client/spring-ws/src/main/java/org/springframework/ws/samples/airline/client/sws/GetFrequentFlyerMileage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/client/spring-ws/src/test/java/org/springframework/ws/samples/airline/client/sws/GetFlightsTest.java
+++ b/airline/client/spring-ws/src/test/java/org/springframework/ws/samples/airline/client/sws/GetFlightsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/FlightDao.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/FlightDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/FrequentFlyerDao.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/FrequentFlyerDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/TicketDao.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/TicketDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/DatabaseInitializer.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/DatabaseInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/JpaFlightDao.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/JpaFlightDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/JpaFrequentFlyerDao.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/JpaFrequentFlyerDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/JpaTicketDao.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/dao/jpa/JpaTicketDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Airport.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Airport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Flight.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Flight.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/FrequentFlyer.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/FrequentFlyer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Passenger.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Passenger.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/ServiceClass.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/ServiceClass.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Ticket.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/Ticket.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/openjpa/DateTimeValueHandler.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/openjpa/DateTimeValueHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/openjpa/LocalDateValueHandler.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/domain/openjpa/LocalDateValueHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/schema/support/SchemaConversionUtils.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/schema/support/SchemaConversionUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/security/FrequentFlyerDetails.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/security/FrequentFlyerDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/security/FrequentFlyerSecurityService.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/security/FrequentFlyerSecurityService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/security/SpringFrequentFlyerSecurityService.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/security/SpringFrequentFlyerSecurityService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/security/StubFrequentFlyerSecurityService.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/security/StubFrequentFlyerSecurityService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/service/AirlineService.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/service/AirlineService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/service/NoSeatAvailableException.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/service/NoSeatAvailableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/service/NoSuchFlightException.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/service/NoSuchFlightException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/service/NoSuchFrequentFlyerException.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/service/NoSuchFrequentFlyerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/service/impl/AirlineServiceImpl.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/service/impl/AirlineServiceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/web/FlightsController.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/web/FlightsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/ws/AirlineEndpoint.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/ws/AirlineEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/main/java/org/springframework/ws/samples/airline/ws/AirlineWebServiceConstants.java
+++ b/airline/server/src/main/java/org/springframework/ws/samples/airline/ws/AirlineWebServiceConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/test/java/org/springframework/ws/samples/airline/dao/jpa/JpaFlightDaoTest.java
+++ b/airline/server/src/test/java/org/springframework/ws/samples/airline/dao/jpa/JpaFlightDaoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/test/java/org/springframework/ws/samples/airline/dao/jpa/JpaFrequentFlyerDaoTest.java
+++ b/airline/server/src/test/java/org/springframework/ws/samples/airline/dao/jpa/JpaFrequentFlyerDaoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/test/java/org/springframework/ws/samples/airline/dao/jpa/JpaTicketDaoTest.java
+++ b/airline/server/src/test/java/org/springframework/ws/samples/airline/dao/jpa/JpaTicketDaoTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/test/java/org/springframework/ws/samples/airline/security/SpringFrequentFlyerSecurityServiceTest.java
+++ b/airline/server/src/test/java/org/springframework/ws/samples/airline/security/SpringFrequentFlyerSecurityServiceTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/test/java/org/springframework/ws/samples/airline/service/impl/AirlineServiceImplTest.java
+++ b/airline/server/src/test/java/org/springframework/ws/samples/airline/service/impl/AirlineServiceImplTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/test/java/org/springframework/ws/samples/airline/web/FlightsControllerTest.java
+++ b/airline/server/src/test/java/org/springframework/ws/samples/airline/web/FlightsControllerTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/airline/server/src/test/java/org/springframework/ws/samples/airline/ws/AirlineEndpointTest.java
+++ b/airline/server/src/test/java/org/springframework/ws/samples/airline/ws/AirlineEndpointTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/README.md
+++ b/echo/README.md
@@ -12,4 +12,4 @@ See the main [README](../README.md) for build instructions.
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
 [Spring Web Services]: https://projects.spring.io/spring-ws
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/echo/client/saaj/src/main/java/org/springframework/ws/samples/echo/client/saaj/EchoClient.java
+++ b/echo/client/saaj/src/main/java/org/springframework/ws/samples/echo/client/saaj/EchoClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/client/spring-ws/src/main/java/org/springframework/ws/samples/echo/client/sws/EchoClient.java
+++ b/echo/client/spring-ws/src/main/java/org/springframework/ws/samples/echo/client/sws/EchoClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/server/src/main/java/org/springframework/ws/samples/echo/config/EchoConfig.java
+++ b/echo/server/src/main/java/org/springframework/ws/samples/echo/config/EchoConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/server/src/main/java/org/springframework/ws/samples/echo/config/EchoServletInitializer.java
+++ b/echo/server/src/main/java/org/springframework/ws/samples/echo/config/EchoServletInitializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/server/src/main/java/org/springframework/ws/samples/echo/service/EchoService.java
+++ b/echo/server/src/main/java/org/springframework/ws/samples/echo/service/EchoService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/server/src/main/java/org/springframework/ws/samples/echo/service/impl/EchoServiceImpl.java
+++ b/echo/server/src/main/java/org/springframework/ws/samples/echo/service/impl/EchoServiceImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/server/src/main/java/org/springframework/ws/samples/echo/ws/EchoEndpoint.java
+++ b/echo/server/src/main/java/org/springframework/ws/samples/echo/ws/EchoEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/echo/server/src/test/java/org/springframework/ws/samples/echo/ws/EchoEndpointTest.java
+++ b/echo/server/src/test/java/org/springframework/ws/samples/echo/ws/EchoEndpointTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mtom/README.md
+++ b/mtom/README.md
@@ -11,4 +11,4 @@ See the main [README](../README.md) for build instructions.
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
 [Spring Web Services]: https://projects.spring.io/spring-ws
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/mtom/client/jax-ws/src/main/java/org/springframework/ws/samples/mtom/client/jaxws/Main.java
+++ b/mtom/client/jax-ws/src/main/java/org/springframework/ws/samples/mtom/client/jaxws/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mtom/client/spring-ws/src/main/java/org/springframework/ws/samples/mtom/client/sws/AxiomMtomClient.java
+++ b/mtom/client/spring-ws/src/main/java/org/springframework/ws/samples/mtom/client/sws/AxiomMtomClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mtom/client/spring-ws/src/main/java/org/springframework/ws/samples/mtom/client/sws/Driver.java
+++ b/mtom/client/spring-ws/src/main/java/org/springframework/ws/samples/mtom/client/sws/Driver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mtom/client/spring-ws/src/main/java/org/springframework/ws/samples/mtom/client/sws/SaajMtomClient.java
+++ b/mtom/client/spring-ws/src/main/java/org/springframework/ws/samples/mtom/client/sws/SaajMtomClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mtom/server/src/main/java/org/springframework/ws/samples/mtom/service/ImageRepository.java
+++ b/mtom/server/src/main/java/org/springframework/ws/samples/mtom/service/ImageRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mtom/server/src/main/java/org/springframework/ws/samples/mtom/service/StubImageRepository.java
+++ b/mtom/server/src/main/java/org/springframework/ws/samples/mtom/service/StubImageRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/mtom/server/src/main/java/org/springframework/ws/samples/mtom/ws/ImageRepositoryEndpoint.java
+++ b/mtom/server/src/main/java/org/springframework/ws/samples/mtom/ws/ImageRepositoryEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/stockquote/README.md
+++ b/stockquote/README.md
@@ -28,4 +28,4 @@ each of client subdirectories:
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
 [Spring Web Services]: https://projects.spring.io/spring-ws
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/stockquote/client/jax-ws/src/main/java/org/springframework/ws/samples/stockquote/client/jaxws/Main.java
+++ b/stockquote/client/jax-ws/src/main/java/org/springframework/ws/samples/stockquote/client/jaxws/Main.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/stockquote/client/spring-ws/src/main/java/org/springframework/ws/samples/stockquote/client/sws/StockClient.java
+++ b/stockquote/client/spring-ws/src/main/java/org/springframework/ws/samples/stockquote/client/sws/StockClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/stockquote/server/src/main/java/org/springframework/ws/samples/stockquote/Driver.java
+++ b/stockquote/server/src/main/java/org/springframework/ws/samples/stockquote/Driver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/stockquote/server/src/main/java/org/springframework/ws/samples/stockquote/ws/StockService.java
+++ b/stockquote/server/src/main/java/org/springframework/ws/samples/stockquote/ws/StockService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -17,4 +17,4 @@ This sample contains the code for the tutorial, which can be found in the
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
 [Spring Web Services]: https://projects.spring.io/spring-ws
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0

--- a/tutorial/src/main/java/com/mycompany/hr/service/HumanResourceService.java
+++ b/tutorial/src/main/java/com/mycompany/hr/service/HumanResourceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tutorial/src/main/java/com/mycompany/hr/service/StubHumanResourceService.java
+++ b/tutorial/src/main/java/com/mycompany/hr/service/StubHumanResourceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tutorial/src/main/java/com/mycompany/hr/ws/HolidayEndpoint.java
+++ b/tutorial/src/main/java/com/mycompany/hr/ws/HolidayEndpoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tutorial/src/main/resources/hr.xsd
+++ b/tutorial/src/main/resources/hr.xsd
@@ -6,7 +6,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/tutorial/src/main/resources/log4j.properties
+++ b/tutorial/src/main/resources/log4j.properties
@@ -5,7 +5,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/tutorial/src/test/java/com/mycompany/hr/ws/HolidayEndpointTest.java
+++ b/tutorial/src/test/java/com/mycompany/hr/ws/HolidayEndpointTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tutorial/src/test/resources/com/mycompany/hr/ws/holidayRequest.xml
+++ b/tutorial/src/test/resources/com/mycompany/hr/ws/holidayRequest.xml
@@ -5,7 +5,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~      https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,

--- a/weather/README.md
+++ b/weather/README.md
@@ -15,5 +15,5 @@ You can run the client by using the following command from within this directory
 [Spring Web Services] is released under version 2.0 of the [Apache License].
 
 [Spring Web Services]: https://projects.spring.io/spring-ws
-[Apache License]: http://www.apache.org/licenses/LICENSE-2.0
+[Apache License]: https://www.apache.org/licenses/LICENSE-2.0
 [CDYNE Weather Service]: https://wiki.cdyne.com/index.php/CDYNE_Weather

--- a/weather/src/main/java/org/springframework/ws/samples/weather/WeatherClient.java
+++ b/weather/src/main/java/org/springframework/ws/samples/weather/WeatherClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/weather/src/main/java/org/springframework/ws/samples/weather/WeatherConfiguration.java
+++ b/weather/src/main/java/org/springframework/ws/samples/weather/WeatherConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 80 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).